### PR TITLE
Feature/issue 170 add badges to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+  - [Issue #170](https://github.com/nasa/stitchee/issues/170): Add PyPI badges to readme
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
     <a href="http://mypy-lang.org/" target="_blank">
         <img src="http://www.mypy-lang.org/static/mypy_badge.svg" alt="Mypy checked">
     </a>
+    <a href="https://pypi.org/project/stitchee/" target="_blank">
+        <img src="https://img.shields.io/pypi/pyversions/stitchee.svg" alt="Python Versions">
+    </a>
+<a href="https://pypi.org/project/stitchee" target="_blank">
+    <img src="https://img.shields.io/pypi/v/stitchee?color=%2334D058label=pypi%20package" alt="Package version">
+</a>
     <a href="https://codecov.io/gh/nasa/stitchee">
      <img src="https://codecov.io/gh/nasa/stitchee/graph/badge.svg?token=WDj92iN7c4" alt="Code coverage">
     </a>


### PR DESCRIPTION
GitHub Issue: #170 

### Description

This change adds two PyPI badges to the README.md

## PR Acceptance Checklist
* [n/a] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).
