### PR TITLE
Feature/issue 181 add argument to change group delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Issue #133](https://github.com/nasa/stitchee/issues/133): Add readthedocs documentation build
 - [Issue #185](https://github.com/nasa/stitchee/issues/185): Added arguments for temporary file copies and overwriting output file in main stitchee function
+- [Issue #181](https://github.com/nasa/stitchee/issues/181): Add a group delimiter argument
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ options:
                         'combine_attrs' argument passed to xarray.concat() or xarray.combine_by_coords().
   --xarray_arg_join XARRAY_ARG_JOIN
                         'join' argument passed to xarray.concat() or xarray.combine_by_coords().
+  --group_delim GROUP_DELIM
+                        Character or string to use as group delimiter
   -O, --overwrite       Overwrite output file if it already exists.
   -v, --verbose         Enable verbose output to stdout; useful for debugging
 

--- a/concatenator/__init__.py
+++ b/concatenator/__init__.py
@@ -14,7 +14,6 @@ class Options:
 
 __version__ = version("stitchee")
 
-global _options
 _options = Options()
 
 
@@ -23,8 +22,14 @@ def __getattr__(name):  # type: ignore
 
     Other unhandled attributes raise as `AttributeError` as expected.
     """
+    global _options
+
     if name == "__options__":
         return _options
+    if name == "group_delim":
+        return _options.group_delim
+    if name == "coord_delim":
+        return _options.coord_delim
     else:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/concatenator/__init__.py
+++ b/concatenator/__init__.py
@@ -1,4 +1,42 @@
 """Convenience variables used across the package."""
 
-GROUP_DELIM = '__'
-COORD_DELIM = "  "
+from dataclasses import dataclass
+from importlib.metadata import version
+
+
+@dataclass
+class Options:
+    """Options for concatenator."""
+
+    group_delim = "__"
+    coord_delim = "  "
+
+
+__version__ = version("stitchee")
+
+global _options
+_options = Options()
+
+
+def __getattr__(name):  # type: ignore
+    """Module-level getattr to handle accessing `concatenator.options`.
+
+    Other unhandled attributes raise as `AttributeError` as expected.
+    """
+    if name == "__options__":
+        return _options
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __setattr__(name, value):  # type: ignore
+    """Module-level setattr to handle setting of `concatenator.options`.
+
+    Other unhandled attributes raise as `AttributeError` as expected.
+    """
+    if name == "group_delim":
+        _options.group_delim = value
+    elif name == "coord_delim":
+        _options.coord_delim = value
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/concatenator/attribute_handling.py
+++ b/concatenator/attribute_handling.py
@@ -13,7 +13,7 @@ import importlib_metadata
 import netCDF4
 import xarray as xr
 
-from concatenator import COORD_DELIM, GROUP_DELIM
+import concatenator
 
 # Values needed for history_json attribute
 HISTORY_JSON_SCHEMA = "https://harmony.earthdata.nasa.gov/schemas/history/0.1.0/history-v0.1.0.json"
@@ -44,10 +44,10 @@ def regroup_coordinate_attribute(attribute_string: str) -> str:
     if len(set(whitespaces)) <= 1:
         new_sep = whitespaces[0]
     else:
-        new_sep = COORD_DELIM
+        new_sep = concatenator.coord_delim
 
     return new_sep.join(
-        "/".join(c.split(GROUP_DELIM))[1:]
+        "/".join(c.split(concatenator.group_delim))[1:]
         for c in attribute_string.split()  # split on any whitespace
     )
 
@@ -87,11 +87,11 @@ def _flatten_coordinate_attribute(attribute_string: str) -> str:
     if len(set(whitespaces)) <= 1:
         new_sep = whitespaces[0]
     else:
-        new_sep = COORD_DELIM
+        new_sep = concatenator.coord_delim
 
     # A new string is constructed.
     return new_sep.join(
-        f'{GROUP_DELIM}{c.replace("/", GROUP_DELIM)}'
+        f'{concatenator.group_delim}{c.replace("/", concatenator.group_delim)}'
         for c in attribute_string.split()  # split on any whitespace
     )
 

--- a/concatenator/dataset_and_group_handling.py
+++ b/concatenator/dataset_and_group_handling.py
@@ -13,7 +13,7 @@ import netCDF4 as nc
 import numpy as np
 import xarray as xr
 
-from concatenator import GROUP_DELIM
+import concatenator
 from concatenator.attribute_handling import (
     flatten_coordinate_attribute_paths,
     regroup_coordinate_attribute,
@@ -32,12 +32,12 @@ def walk(
 ):
     """Recursive function to step through each group and subgroup."""
     for key, item in group_node.items():
-        group_path = f"{path}{GROUP_DELIM}{key}"
+        group_path = f"{path}{concatenator.group_delim}{key}"
 
         if item.dimensions:
             dims = list(item.dimensions.keys())
             for dim_name in dims:
-                new_dim_name = f'{group_path.replace("/", GROUP_DELIM)}{GROUP_DELIM}{dim_name}'
+                new_dim_name = f'{group_path.replace("/", concatenator.group_delim)}{concatenator.group_delim}{dim_name}'
                 item.dimensions[new_dim_name] = item.dimensions[dim_name]
                 dimensions_dict_to_populate[new_dim_name] = item.dimensions[dim_name]
                 item.renameDimension(dim_name, new_dim_name)
@@ -47,7 +47,7 @@ def walk(
         if item.variables:
             # Copy variables to root group with new name
             for var_name, var in item.variables.items():
-                var_group_name = f"{group_path}{GROUP_DELIM}{var_name}"
+                var_group_name = f"{group_path}{concatenator.group_delim}{var_name}"
                 new_dataset.variables[var_group_name] = var
 
                 # Flatten the paths of variables referenced in the coordinates attribute
@@ -88,7 +88,7 @@ def flatten_grouped_dataset(
     dataset. xarray does not work with groups, so this transformation
     will flatten the variables in the dataset and use the group path as
     the new variable name. For example, data_01 > km > sst would become
-    'data_01__km__sst', where GROUP_DELIM is __.
+    'data_01__km__sst', where concatenator.group_delim is __.
 
     This same pattern is applied to dimensions, which are located under
     the appropriate group. They are renamed and placed in the root
@@ -109,14 +109,14 @@ def flatten_grouped_dataset(
     dimensions = {}
 
     # for var_name in list(nc_dataset.variables.keys()):
-    #     new_var_name = f'{GROUP_DELIM}{var_name}'
+    #     new_var_name = f'{concatenator.group_delim}{var_name}'
     #     nc_dataset.variables[new_var_name] = nc_dataset.variables[var_name]
     #     del nc_dataset.variables[var_name]
 
     if nc_dataset.variables:
         temp_copy_for_iterating = list(nc_dataset.variables.items())
         for var_name, var in temp_copy_for_iterating:
-            new_var_name = f"{GROUP_DELIM}{var_name}"
+            new_var_name = f"{concatenator.group_delim}{var_name}"
 
             # ds_new.variables[new_var_name] = ds_old.variables[var_name]
 
@@ -132,7 +132,7 @@ def flatten_grouped_dataset(
     if nc_dataset.dimensions:
         temp_copy_for_iterating = list(nc_dataset.dimensions.keys())
         for dim_name in temp_copy_for_iterating:
-            new_dim_name = f"{GROUP_DELIM}{dim_name}"
+            new_dim_name = f"{concatenator.group_delim}{dim_name}"
             # dimensions[new_dim_name] = item.dimensions[dim_name]
             # item.renameDimension(dim_name, new_dim_name)
             # ds_new.dimensions[new_dim_name] = item.dimensions[dim_name]
@@ -184,7 +184,7 @@ def regroup_flattened_dataset(
         group_lst = []
         # need logic if there is data in the top level not in a group
         for var_name, _ in dataset.variables.items():
-            group_lst.append("/".join(str(var_name).split(GROUP_DELIM)[:-1]))
+            group_lst.append("/".join(str(var_name).split(concatenator.group_delim)[:-1]))
         group_lst = ["/" if group == "" else group for group in group_lst]
         groups = set(group_lst)
         for group in groups:
@@ -192,7 +192,7 @@ def regroup_flattened_dataset(
 
         # Copy dimensions
         for dim_name, _ in dataset.dims.items():
-            new_dim_name = str(dim_name).rsplit(GROUP_DELIM, 1)[-1]
+            new_dim_name = str(dim_name).rsplit(concatenator.group_delim, 1)[-1]
             dim_group = _get_nested_group(base_dataset, str(dim_name))
             dim_group.createDimension(new_dim_name, dataset.dims[dim_name])
             # dst.createDimension(
@@ -200,9 +200,9 @@ def regroup_flattened_dataset(
 
         # Copy variables
         for var_name, var in dataset.variables.items():
-            new_var_name = str(var_name).rsplit(GROUP_DELIM, 1)[-1]
+            new_var_name = str(var_name).rsplit(concatenator.group_delim, 1)[-1]
             var_group = _get_nested_group(base_dataset, str(var_name))
-            # grouping = '/'.join(var_name.split(GROUP_DELIM)[:-1])
+            # grouping = '/'.join(var_name.split(concatenator.group_delim)[:-1])
             try:
                 this_dtype = var.dtype
 
@@ -222,7 +222,9 @@ def regroup_flattened_dataset(
                     new_var_dims = (new_var_name,)
                     chunk_sizes = None
                 else:
-                    new_var_dims = tuple(str(d).rsplit(GROUP_DELIM, 1)[-1] for d in var.dims)
+                    new_var_dims = tuple(
+                        str(d).rsplit(concatenator.group_delim, 1)[-1] for d in var.dims
+                    )
                     dim_sizes = [_get_dimension_size(base_dataset, dim) for dim in new_var_dims]
 
                     chunk_sizes = _calculate_chunks(dim_sizes, default_low_dim_chunksize=4000)
@@ -266,7 +268,7 @@ def regroup_flattened_dataset(
 
 def _get_nested_group(dataset: nc.Dataset, group_path: str) -> nc.Group:
     nested_group = dataset
-    for group in group_path.strip(GROUP_DELIM).split(GROUP_DELIM)[:-1]:
+    for group in group_path.strip(concatenator.group_delim).split(concatenator.group_delim)[:-1]:
         nested_group = nested_group.groups[group]
     return nested_group
 

--- a/concatenator/run_stitchee.py
+++ b/concatenator/run_stitchee.py
@@ -12,7 +12,7 @@ from concatenator.file_ops import validate_input_path, validate_output_path
 from concatenator.stitchee import stitchee
 
 
-def parse_args(args: list) -> tuple[list[str], str, str, bool, str, dict, bool]:
+def parse_args(args: list) -> tuple[list[str], str, str, bool, str, dict, bool, str]:
     """
     Parse args for this script.
 
@@ -85,6 +85,11 @@ def parse_args(args: list) -> tuple[list[str], str, str, bool, str, dict, bool]:
         "-O", "--overwrite", action="store_true", help="Overwrite output file if it already exists."
     )
     parser.add_argument(
+        "--group_delim",
+        help="Character or string to use as group delimiter.",
+        default="__",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         help="Enable verbose output to stdout; useful for debugging",
@@ -130,6 +135,7 @@ def parse_args(args: list) -> tuple[list[str], str, str, bool, str, dict, bool]:
         parsed.concat_method,
         concat_kwargs,
         parsed.copy_input_files,
+        parsed.group_delim,
     )
 
 
@@ -145,6 +151,7 @@ def run_stitchee(args: list) -> None:
         concat_method,
         concat_kwargs,
         copy_input_files,
+        group_delimiter,
     ) = parse_args(args)
     num_inputs = len(input_files)
 
@@ -168,6 +175,7 @@ def run_stitchee(args: list) -> None:
         concat_kwargs=concat_kwargs,
         history_to_append=new_history_json,
         copy_input_files=copy_input_files,
+        group_delimiter=group_delimiter,
     )
     logging.info("STITCHEE complete. Result in %s", output_path)
 

--- a/concatenator/run_stitchee.py
+++ b/concatenator/run_stitchee.py
@@ -82,12 +82,12 @@ def parse_args(args: list) -> tuple[list[str], str, str, bool, str, dict, bool, 
         help="'join' argument passed to xarray.concat() or xarray.combine_by_coords().",
     )
     parser.add_argument(
-        "-O", "--overwrite", action="store_true", help="Overwrite output file if it already exists."
-    )
-    parser.add_argument(
         "--group_delim",
         help="Character or string to use as group delimiter.",
         default="__",
+    )
+    parser.add_argument(
+        "-O", "--overwrite", action="store_true", help="Overwrite output file if it already exists."
     )
     parser.add_argument(
         "-v",

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import netCDF4 as nc
 import pytest
 
-from concatenator.dataset_and_group_handling import GROUP_DELIM
+import concatenator
 from concatenator.stitchee import stitchee
 
 from . import data_for_tests_dir
@@ -54,12 +54,16 @@ class TestConcat:
                 try:
                     original_files_length_sum += ncds.dimensions[record_dim_name].size
                 except KeyError:
-                    original_files_length_sum += ncds.dimensions[GROUP_DELIM + record_dim_name].size
+                    original_files_length_sum += ncds.dimensions[
+                        concatenator.group_delim + record_dim_name
+                    ].size
 
         try:
             merged_file_length = merged_dataset.dimensions[record_dim_name].size
         except KeyError:
-            merged_file_length = merged_dataset.dimensions[GROUP_DELIM + record_dim_name].size
+            merged_file_length = merged_dataset.dimensions[
+                concatenator.group_delim + record_dim_name
+            ].size
 
         assert original_files_length_sum == merged_file_length
 


### PR DESCRIPTION
GitHub Issue: #181 

### Description

This change adds a `group_delim` argument to the command line interface and to the function signature of `stitchee()`

### Local test steps

Ran the `run_stitchee` CLI locally, and verified that the `concatenator.group_delim` was being set correctly and maintaining its value across modules.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--189.org.readthedocs.build/en/189/

<!-- readthedocs-preview stitchee end -->