### PR TITLE
Fix integration test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- [Issue #204](https://github.com/nasa/stitchee/issues/204): Fix integration test failure
 
 ## [1.2.1]
 

--- a/tests/integration/test_concat_with_subsetting_first.py
+++ b/tests/integration/test_concat_with_subsetting_first.py
@@ -17,6 +17,7 @@ def test_concat_with_subsetting_first(temp_output_dir):
             "stop": dt.datetime(2024, 5, 13, 20, 0, 0),
         },
         spatial=BBox(-130, 30, -115, 35),
+        concatenate=False,
     )
     if not request.is_valid():
         raise RuntimeError

--- a/tests/integration/test_concat_with_subsetting_first.py
+++ b/tests/integration/test_concat_with_subsetting_first.py
@@ -29,6 +29,7 @@ def test_concat_with_subsetting_first(temp_output_dir):
     # Download the result files.
     futures = harmony_client.download_all(job_id, directory=str(temp_output_dir))
     file_names = [f.result() for f in futures]
+    print(f"File names: {file_names}")
 
     # Try concatenating the resulting files
     output_path = stitchee(


### PR DESCRIPTION
GitHub Issue: #204

### Description

This fixes the integration test failures that were happening because concatenation was happening even though `concatenate=true` was not passed to the Harmony request.

@chris-durbin helped diagnose the issue, and it was determined that in Harmony, currently 
`      concatenate_by_default: true`
So that "...if the SAMBAH chain is selected, the concatenate is true unless explicitly false."

We're pretty sure this logic/behavior was hidden and we avoided seeing it before because we had the l2-subsetter service associated to the collections also.  Thus, when a request didn't have concatenate, it was processed by the standalone l2-susbetter service, not SAMBAH.  However, as of now, we don't have the l2-subsetter standalone service associated, so it's all on the SAMBAH configuration logic.

### Overview of integration done

Passing the integration test again.

## PR Acceptance Checklist
* [n/a] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--205.org.readthedocs.build/en/205/

<!-- readthedocs-preview stitchee end -->