### PR TITLE
Feature/issue 225 use common changelog style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.3.0] - 2024-07-10
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Group dependabot updates into one PR ([#206](https://github.com/nasa/stitchee/issues/206))([**@danielfromearth**](https://github.com/danielfromearth))
 - Increase continuous integration/unit test coverage ([#208](https://github.com/nasa/stitchee/issues/208))([**@danielfromearth**](https://github.com/danielfromearth))
 - Use time variable instead of concat dim for ordering datasets ([#198](https://github.com/nasa/stitchee/issues/198))([**@danielfromearth**](https://github.com/danielfromearth), [**@ank1m**](https://github.com/ank1m))
+- Update `CHANGELOG.md` to follow Common Changelog conventions ([#226](https://github.com/nsidc/earthaccess/pull/226))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,56 +30,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update UMM-S record ID ([#183](https://github.com/nasa/stitchee/issues/183))
+- Update UMM-S record ID ([#183](https://github.com/nasa/stitchee/issues/183))([**@danielfromearth**](https://github.com/danielfromearth), [**@ank1m**](https://github.com/ank1m))
 
 ## [1.2.0]
 
 ### Changed
 
-- Propagate first empty granule if all input files are empty ([#153](https://github.com/nasa/stitchee/issues/153))
-- Remove compression for string array of small size ([#168](https://github.com/nasa/stitchee/issues/168))
+- Propagate first empty granule if all input files are empty ([#153](https://github.com/nasa/stitchee/issues/153))([**@ank1m**](https://github.com/ank1m), [**@danielfromearth**](https://github.com/danielfromearth))
+- Remove compression for string array of small size ([#168](https://github.com/nasa/stitchee/issues/168))([**@ank1m**](https://github.com/ank1m), [**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Added
 
-- Add PyPI badges to readme ([#170](https://github.com/nasa/stitchee/issues/170))
+- Add PyPI badges to readme ([#170](https://github.com/nasa/stitchee/issues/170))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Fixed
 
-- Resolve linting error ([#177](https://github.com/nasa/stitchee/pull/177))
+- Resolve linting error ([#177](https://github.com/nasa/stitchee/pull/177))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ## [1.1.0]
 
 ### Added
 
-- Add code coverage to CI pipeline ([#164](https://github.com/nasa/stitchee/pull/164))
+- Add code coverage to CI pipeline ([#164](https://github.com/nasa/stitchee/pull/164))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ## [1.0.0]
 
 ### Changed
 
-- Change name to "stitchee" ([#12](https://github.com/danielfromearth/stitchee/pull/12))
-- Use ruff+black chain for pre-commit lint & format ([#15](https://github.com/danielfromearth/stitchee/pull/15))
-- Rename CLI argument to clarify temporary copying behavior ([#45](https://github.com/danielfromearth/stitchee/issues/45))
-- Concatenation dimension CLI argument is required but isn't listed as such in the help message ([#44](https://github.com/danielfromearth/stitchee/issues/44))
-- Remove `nco` related code ([#81](https://github.com/danielfromearth/stitchee/issues/81))
-- Sort according to extend dimension ([#129](https://github.com/danielfromearth/stitchee/pull/129))
-- Consider empty a netCDF with only singleton null-values ([#152](https://github.com/danielfromearth/stitchee/pull/152))
-- Update CI pipeline ([#157](https://github.com/danielfromearth/stitchee/pull/157))
-- Add pypi publishing steps to CI pipeline ([#158](https://github.com/danielfromearth/stitchee/pull/158))
+- Change name to "stitchee" ([#12](https://github.com/danielfromearth/stitchee/pull/12))([**@danielfromearth**](https://github.com/danielfromearth))
+- Use ruff+black chain for pre-commit lint & format ([#15](https://github.com/danielfromearth/stitchee/pull/15))([**@danielfromearth**](https://github.com/danielfromearth))
+- Rename CLI argument to clarify temporary copying behavior ([#45](https://github.com/danielfromearth/stitchee/issues/45))([**@danielfromearth**](https://github.com/danielfromearth))
+- Remove `nco` related code ([#83](https://github.com/nasa/stitchee/pull/83))([**@danielfromearth**](https://github.com/danielfromearth))
+- Sort according to extend dimension ([#129](https://github.com/danielfromearth/stitchee/pull/129))([**@danielfromearth**](https://github.com/danielfromearth))
+- Consider empty a netCDF with only singleton null-values ([#152](https://github.com/danielfromearth/stitchee/pull/152))([**@danielfromearth**](https://github.com/danielfromearth), [**@ank1m**](https://github.com/ank1m))
+- Update CI pipeline ([#157](https://github.com/danielfromearth/stitchee/pull/157))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add pypi publishing steps to CI pipeline ([#158](https://github.com/danielfromearth/stitchee/pull/158))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Added
 
-- An initial GitHub Actions workflow ([#1](https://github.com/danielfromearth/stitchee/pull/1))
-- Create working Docker image ([#8](https://github.com/danielfromearth/stitchee/issues/8))
-- Add code necessary to communicate with Harmony ([#10](https://github.com/danielfromearth/stitchee/issues/10))
-- More CLI arguments for finer control of concatenation method ([#49](https://github.com/danielfromearth/stitchee/issues/49))
-- Add Docker build steps to GitHub Actions workflow ([#99](https://github.com/danielfromearth/stitchee/pull/99))
-- Add history attributes ([#113](https://github.com/danielfromearth/stitchee/pull/113))
-- Add readme badges ([#115](https://github.com/danielfromearth/stitchee/pull/115))
-- Add tutorial Jupyter notebook ([#116](https://github.com/danielfromearth/stitchee/pull/116))
-- Create toy netCDFs in testing suite ([#128](https://github.com/danielfromearth/stitchee/pull/116))
+- An initial GitHub Actions workflow ([#1](https://github.com/danielfromearth/stitchee/pull/1))([**@danielfromearth**](https://github.com/danielfromearth))
+- Create working Docker image ([#40](https://github.com/nasa/stitchee/pull/40))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add code necessary to communicate with Harmony ([#40](https://github.com/nasa/stitchee/pull/40))([**@danielfromearth**](https://github.com/danielfromearth))
+- More CLI arguments for finer control of concatenation method ([#50](https://github.com/nasa/stitchee/pull/50))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add Docker build steps to GitHub Actions workflow ([#99](https://github.com/danielfromearth/stitchee/pull/99), [#108](https://github.com/nasa/stitchee/pull/108))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add history attributes ([#113](https://github.com/danielfromearth/stitchee/pull/113))([**@danielfromearth**](https://github.com/danielfromearth), [**@ank1m**](https://github.com/ank1m))
+- Add readme badges ([#115](https://github.com/danielfromearth/stitchee/pull/115))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add tutorial Jupyter notebook ([#116](https://github.com/danielfromearth/stitchee/pull/116))([**@ank1m**](https://github.com/ank1m), [**@danielfromearth**](https://github.com/danielfromearth))
+- Create toy netCDFs in testing suite ([#128](https://github.com/danielfromearth/stitchee/pull/128))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Fixed
 
-- Error with TEMPO ozone profile data because of duplicated dimension names ([#4](https://github.com/danielfromearth/stitchee/pull/4))
-- Fix conflicting dimensions on record dimension sorting ([#136](https://github.com/danielfromearth/stitchee/pull/136))
+- Error with TEMPO ozone profile data because of duplicated dimension names ([#4](https://github.com/danielfromearth/stitchee/pull/4))([**@danielfromearth**](https://github.com/danielfromearth))
+- Fix conflicting dimensions on record dimension sorting ([#136](https://github.com/danielfromearth/stitchee/pull/136))([**@danielfromearth**](https://github.com/danielfromearth), [**@ank1m**](https://github.com/ank1m))
+- Concatenation dimension CLI argument is required but isn't listed as such in the help message ([#44](https://github.com/danielfromearth/stitchee/issues/44))([**@danielfromearth**](https://github.com/danielfromearth))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,78 +4,82 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0]
+## [1.3.0] - 2024-07-10
+
+### Changed
+
+- Group dependabot updates into one PR ([#206](https://github.com/nasa/stitchee/issues/206))([**@danielfromearth**](https://github.com/danielfromearth))
+- Increase continuous integration/unit test coverage ([#208](https://github.com/nasa/stitchee/issues/208))([**@danielfromearth**](https://github.com/danielfromearth))
+- Use time variable instead of concat dim for ordering datasets ([#198](https://github.com/nasa/stitchee/issues/198))([**@danielfromearth**](https://github.com/danielfromearth), [**@ank1m**](https://github.com/ank1m))
 
 ### Added
-- [Issue #133](https://github.com/nasa/stitchee/issues/133): Add readthedocs documentation build
-- [Issue #185](https://github.com/nasa/stitchee/issues/185): Added arguments for temporary file copies and overwriting output file in main stitchee function
-- [Issue #181](https://github.com/nasa/stitchee/issues/181): Add a group delimiter argument
-- [Issue #134](https://github.com/nasa/stitchee/issues/134): Add an integration test that runs stitchee on files first subsetted by the operational Harmony subsetter
-- [Issue #194](https://github.com/nasa/stitchee/issues/194): Add page about the SAMBAH service chain to the Readthedocs documentation
-- [issue #193](https://github.com/nasa/stitchee/issues/193): Add autoupdate schedule for pre-commit
-### Changed
-- [Issue #206](https://github.com/nasa/stitchee/issues/206): Group dependabot updates into one PR
-- [issue #208](https://github.com/nasa/stitchee/issues/208): Increase continuous integration/unit test coverage
-- [issue #198](https://github.com/nasa/stitchee/issues/198): Use time variable instead of concat dim for ordering datasets
-### Deprecated
-### Removed
+
+- Add readthedocs documentation build ([#133](https://github.com/nasa/stitchee/issues/133))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add arguments for temporary file copies and overwriting output file in main stitchee function ([#185](https://github.com/nasa/stitchee/issues/185))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add a group delimiter argument ([#181](https://github.com/nasa/stitchee/issues/181))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add an integration test that runs stitchee on files first subsetted by the operational Harmony subsetter ([#134](https://github.com/nasa/stitchee/issues/134))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add page about the SAMBAH service chain to the Readthedocs documentation ([#194](https://github.com/nasa/stitchee/issues/194))([**@danielfromearth**](https://github.com/danielfromearth))
+- Add autoupdate schedule for pre-commit ([#193](https://github.com/nasa/stitchee/issues/193))([**@danielfromearth**](https://github.com/danielfromearth))
+
 ### Fixed
-- [Issue #204](https://github.com/nasa/stitchee/issues/204): Fix integration test failure
+
+- Fix integration test failure ([#204](https://github.com/nasa/stitchee/issues/204))([**@danielfromearth**](https://github.com/danielfromearth))
+
 
 ## [1.2.1]
 
-### Added
 ### Changed
-  - [Issue #183](https://github.com/nasa/stitchee/issues/183): Update UMM-S record ID
-### Deprecated
-### Removed
-### Fixed
+
+- Update UMM-S record ID ([#183](https://github.com/nasa/stitchee/issues/183))
 
 ## [1.2.0]
 
-### Added
-  - [Issue #170](https://github.com/nasa/stitchee/issues/170): Add PyPI badges to readme
 ### Changed
-  - [Issue #153](https://github.com/nasa/stitchee/issues/153): propagate first empty granule if all input files are empty
-  - [Issue #168](https://github.com/nasa/stitchee/issues/168): remove compression for string array of small size
-### Deprecated
-### Removed
+
+- Propagate first empty granule if all input files are empty ([#153](https://github.com/nasa/stitchee/issues/153))
+- Remove compression for string array of small size ([#168](https://github.com/nasa/stitchee/issues/168))
+
+### Added
+
+- Add PyPI badges to readme ([#170](https://github.com/nasa/stitchee/issues/170))
+
 ### Fixed
-  - [Pull #177](https://github.com/nasa/stitchee/pull/177): Resolve linting error
+
+- Resolve linting error ([#177](https://github.com/nasa/stitchee/pull/177))
 
 ## [1.1.0]
 
 ### Added
-  - [Pull #164](https://github.com/nasa/stitchee/pull/164): Add code coverage to CI pipeline
-### Changed
-### Deprecated
-### Removed
-### Fixed
+
+- Add code coverage to CI pipeline ([#164](https://github.com/nasa/stitchee/pull/164))
 
 ## [1.0.0]
 
-### Added
-  - [Pull #1](https://github.com/danielfromearth/stitchee/pull/1): An initial GitHub Actions workflow
-  - [Issue #8](https://github.com/danielfromearth/stitchee/issues/8): Create working Docker image
-  - [Issue #10](https://github.com/danielfromearth/stitchee/issues/10): Add code necessary to communicate with Harmony
-  - [Issue #49](https://github.com/danielfromearth/stitchee/issues/49): More CLI arguments for finer control of concatenation method
-  - [Pull #99](https://github.com/danielfromearth/stitchee/pull/99): Add Docker build steps to GitHub Actions workflow
-  - [Pull #113](https://github.com/danielfromearth/stitchee/pull/113): Add history attributes
-  - [Pull #115](https://github.com/danielfromearth/stitchee/pull/115): Add readme badges
-  - [Pull #116](https://github.com/danielfromearth/stitchee/pull/116): Add tutorial Jupyter notebook
-  - [Pull #128](https://github.com/danielfromearth/stitchee/pull/116): Create toy netCDFs in testing suite
 ### Changed
-  - [Pull #12](https://github.com/danielfromearth/stitchee/pull/12): Changed name to "stitchee"
-  - [Pull #15](https://github.com/danielfromearth/stitchee/pull/15): Use ruff+black chain for pre-commit lint & format
-  - [Issue #45](https://github.com/danielfromearth/stitchee/issues/45): Rename CLI argument to clarify temporary copying behavior
-  - [Issue #44](https://github.com/danielfromearth/stitchee/issues/44): Concatenation dimension CLI argument is required but isn't listed as such in the help message
-  - [Issue #81](https://github.com/danielfromearth/stitchee/issues/81): Remove `nco` related code
-  - [Pull #129](https://github.com/danielfromearth/stitchee/pull/129): Sort according to extend dimension
-  - [Pull #152](https://github.com/danielfromearth/stitchee/pull/152): Consider empty a netCDF with only singleton null-values
-  - [Pull #157](https://github.com/danielfromearth/stitchee/pull/157): Update CI pipeline
-  - [Pull #158](https://github.com/danielfromearth/stitchee/pull/158): Add pypi publishing steps to CI pipeline
-### Deprecated
-### Removed
+
+- Change name to "stitchee" ([#12](https://github.com/danielfromearth/stitchee/pull/12))
+- Use ruff+black chain for pre-commit lint & format ([#15](https://github.com/danielfromearth/stitchee/pull/15))
+- Rename CLI argument to clarify temporary copying behavior ([#45](https://github.com/danielfromearth/stitchee/issues/45))
+- Concatenation dimension CLI argument is required but isn't listed as such in the help message ([#44](https://github.com/danielfromearth/stitchee/issues/44))
+- Remove `nco` related code ([#81](https://github.com/danielfromearth/stitchee/issues/81))
+- Sort according to extend dimension ([#129](https://github.com/danielfromearth/stitchee/pull/129))
+- Consider empty a netCDF with only singleton null-values ([#152](https://github.com/danielfromearth/stitchee/pull/152))
+- Update CI pipeline ([#157](https://github.com/danielfromearth/stitchee/pull/157))
+- Add pypi publishing steps to CI pipeline ([#158](https://github.com/danielfromearth/stitchee/pull/158))
+
+### Added
+
+- An initial GitHub Actions workflow ([#1](https://github.com/danielfromearth/stitchee/pull/1))
+- Create working Docker image ([#8](https://github.com/danielfromearth/stitchee/issues/8))
+- Add code necessary to communicate with Harmony ([#10](https://github.com/danielfromearth/stitchee/issues/10))
+- More CLI arguments for finer control of concatenation method ([#49](https://github.com/danielfromearth/stitchee/issues/49))
+- Add Docker build steps to GitHub Actions workflow ([#99](https://github.com/danielfromearth/stitchee/pull/99))
+- Add history attributes ([#113](https://github.com/danielfromearth/stitchee/pull/113))
+- Add readme badges ([#115](https://github.com/danielfromearth/stitchee/pull/115))
+- Add tutorial Jupyter notebook ([#116](https://github.com/danielfromearth/stitchee/pull/116))
+- Create toy netCDFs in testing suite ([#128](https://github.com/danielfromearth/stitchee/pull/116))
+
 ### Fixed
-- [Pull #4](https://github.com/danielfromearth/stitchee/pull/4): Error with TEMPO ozone profile data because of duplicated dimension names
-- [Pull #133](https://github.com/danielfromearth/stitchee/pull/133): Fix conflicting dimensions on record dimension sorting
+
+- Error with TEMPO ozone profile data because of duplicated dimension names ([#4](https://github.com/danielfromearth/stitchee/pull/4))
+- Fix conflicting dimensions on record dimension sorting ([#133](https://github.com/danielfromearth/stitchee/pull/133))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,4 +82,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Error with TEMPO ozone profile data because of duplicated dimension names ([#4](https://github.com/danielfromearth/stitchee/pull/4))
-- Fix conflicting dimensions on record dimension sorting ([#133](https://github.com/danielfromearth/stitchee/pull/133))
+- Fix conflicting dimensions on record dimension sorting ([#136](https://github.com/danielfromearth/stitchee/pull/136))


### PR DESCRIPTION
GitHub Issue: #225 

### Description

This changes the CHANGELOG so that it follows the Common Changelog format.

## PR Acceptance Checklist
* [n/a] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [n/a] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--226.org.readthedocs.build/en/226/

<!-- readthedocs-preview stitchee end -->