### PR TITLE
Feature/issue 233 sorting variable arg in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Allow single netCDF file input in addition to single text file listings ([#230](https://github.com/nasa/stitchee/issues/230))([**@danielfromearth**](https://github.com/danielfromearth))
 - Remove the dask dependency ([#235](https://github.com/nasa/stitchee/issues/235))([**@danielfromearth**](https://github.com/danielfromearth))
+- Expose sorting variable argument in the command line interface ([#233](https://github.com/nasa/stitchee/issues/233))([**@danielfromearth**](https://github.com/danielfromearth))
 
 
 ## [1.3.0] - 2024-07-11

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ options:
                         Whether to use the xarray concat method or the combine-by-coords method.
   --concat_dim CONCAT_DIM
                         Dimension to concatenate along, if possible. This is required if using the 'xarray-concat' method
+  --sorting_variable SORTING_VARIABLE
+                        Name of a variable to use for sorting datasets before concatenation by xarray. E.g., 'time'.
   --xarray_arg_compat XARRAY_ARG_COMPAT
                         'compat' argument passed to xarray.concat() or xarray.combine_by_coords().
   --xarray_arg_combine_attrs XARRAY_ARG_COMBINE_ATTRS

--- a/concatenator/harmony/service_adapter.py
+++ b/concatenator/harmony/service_adapter.py
@@ -123,6 +123,7 @@ class StitcheeAdapter(BaseHarmonyAdapter):
                     write_tmp_flat_concatenated=False,
                     keep_tmp_files=False,
                     concat_dim="mirror_step",  # This is currently set only for TEMPO
+                    sorting_variable="geolocation/time",  # This is currently set only for TEMPO
                     history_to_append=new_history_json,
                     logger=self.logger,
                 )

--- a/concatenator/run_stitchee.py
+++ b/concatenator/run_stitchee.py
@@ -70,6 +70,11 @@ def parse_args(args: list) -> argparse.Namespace:
         "This is required if using the 'xarray-concat' method",
     )
     parser.add_argument(
+        "--sorting_variable",
+        help="Name of a variable to use for sorting datasets before concatenation by xarray. "
+        "E.g., 'time'.",
+    )
+    parser.add_argument(
         "--xarray_arg_compat",
         help="'compat' argument passed to xarray.concat() or xarray.combine_by_coords().",
     )

--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -40,7 +40,7 @@ def stitchee(
     concat_method: str | None = "xarray-concat",
     concat_dim: str = "",
     concat_kwargs: dict | None = None,
-    time_variable: str = "geolocation/time",
+    sorting_variable: str | None = None,
     history_to_append: str | None = None,
     copy_input_files: bool = False,
     overwrite_output_file: bool = False,
@@ -62,11 +62,15 @@ def stitchee(
     concat_method
         either "xarray-concat" (default) or "xarray-combine".
     concat_dim
-        dimension along which to concatenate (default: ""). Not needed is concat_method is "xarray-combine".
+        dimension along which to concatenate (default: "").
+        Not needed if concat_method is "xarray-combine".
     concat_kwargs
         keyword arguments to pass to xarray.concat or xarray.combine_by_coords (default: None).
+    sorting_variable
+        name of a variable to use for sorting datasets before concatenation by xarray.
+        E.g., `time`.
     history_to_append
-        json string to append to the history attribute of the concatenated file (default: None).
+        JSON string to append to the history attribute of the concatenated file (default: None).
     copy_input_files
         whether to copy input files or not (default: False).
     overwrite_output_file
@@ -140,7 +144,12 @@ def stitchee(
                 )
 
                 # Determine value for later dataset sorting.
-                first_value = xrds[flatten_string_with_groups(time_variable)].values.flatten()[0]
+                if sorting_variable:
+                    first_value = xrds[
+                        flatten_string_with_groups(sorting_variable)
+                    ].values.flatten()[0]
+                else:
+                    first_value = i
                 # first_value = xrds[concatenator.group_delim + concat_dim].values.flatten()[0]
                 concat_dim_order.append(first_value)
 
@@ -194,7 +203,7 @@ def stitchee(
 
             if write_tmp_flat_concatenated:
                 logger.info("Writing concatenated flattened temporary file to disk...")
-                # Concatenated, yet still flat, file is written to disk for debugging.
+                # The concatenated, yet still flat, file is written to disk for debugging.
                 tmp_flat_concatenated_path = add_label_to_path(
                     output_file, label="_flat_intermediate"
                 )

--- a/tests/integration/test_history_construction.py
+++ b/tests/integration/test_history_construction.py
@@ -28,7 +28,7 @@ def test_construct_and_append_history_for_sample_concatenation(
         concat_method="xarray-concat",
         history_to_append=new_history_json,
         concat_dim="step",
-        time_variable="step",
+        sorting_variable="step",
     )
     stitcheed_dataset = xr.open_dataset(output_path)
 


### PR DESCRIPTION
GitHub Issue: #233 

### Description

Renamed `time_variable` to `sorting_variable` to better reflect its purpose.  Exposed this variable in the CLI, and moved the default for TEMPO into the Harmony adapter and out of the stitchee core code. 

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--238.org.readthedocs.build/en/238/

<!-- readthedocs-preview stitchee end -->