### PR TITLE
prevent xarray from changing variable types on open_dataset

### DIFF
--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -150,6 +150,7 @@ def stitchee(
                     decode_times=False,
                     decode_coords=False,
                     drop_variables=coord_vars,
+                    mask_and_scale=False
                 )
 
                 # Determine value for later dataset sorting.

--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -150,7 +150,7 @@ def stitchee(
                     decode_times=False,
                     decode_coords=False,
                     drop_variables=coord_vars,
-                    mask_and_scale=False
+                    mask_and_scale=False,
                 )
 
                 # Determine value for later dataset sorting.


### PR DESCRIPTION
GitHub Issue: 253

### Description

Stitchee is inadvertently changing the data type for the main_data_quality_flag variable in TEMPO data, from int16 to float32. This impacts the SAMBAH service chain for certain edge cases (multi-file scans combining with single-file scans), because CONCISE raises an error when it encounters differing data types for the same variable.

### Local test steps

Checked `product/main_data_quality_flag` in the output using standalone stitchee and in local Harmony environment before and after adding `mask_and_scale` parameter in the `xarray.open_dataset` function:
|  | Type in the original granule | Type in the stitched file | Harmony request status |
|----| ------ | ----- | ----- |
| Before `mask_and_scale` | int16 | float | Failure on CONCISE step |
| After `mask_and_scale` |int16 | int16 | Success |

### Overview of integration done
- Deployed stitchee in local Harmony environment
- Performed previous egde-case requests without failures

## PR Acceptance Checklist
* [ ] Unit tests added/updated and passing.
* [x] Integration testing
* [ ] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--254.org.readthedocs.build/en/254/

<!-- readthedocs-preview stitchee end -->