### PR TITLE
Feature/issue 138 migrate to xarray.DataTree

### DIFF
--- a/concatenator/harmony/service_adapter.py
+++ b/concatenator/harmony/service_adapter.py
@@ -120,8 +120,6 @@ class StitcheeAdapter(BaseHarmonyAdapter):
                 stitchee(
                     [str(f) for f in input_files],
                     output_path,
-                    write_tmp_flat_concatenated=False,
-                    keep_tmp_files=False,
                     concat_dim="mirror_step",  # This is currently set only for TEMPO
                     sorting_variable="geolocation/time",  # This is currently set only for TEMPO
                     history_to_append=new_history_json,

--- a/concatenator/run_stitchee.py
+++ b/concatenator/run_stitchee.py
@@ -45,21 +45,6 @@ def parse_args(args: list) -> argparse.Namespace:
 
     # Optional arguments
     parser.add_argument(
-        "--copy_input_files",
-        action="store_true",
-        help="By default, input files are not copied. "
-        "This option copies the input files into a temporary directory to avoid modification "
-        "of input files. This is useful for testing, but uses more disk space.  "
-        "By specifying this argument, no copying is performed.",
-    )
-    parser.add_argument(
-        "--keep_tmp_files",
-        action="store_true",
-        help="Prevents removal, after successful execution, of "
-        "(1) the flattened concatenated file and "
-        "(2) the input directory copy  if created by '--make_dir_copy'.",
-    )
-    parser.add_argument(
         "--concat_method",
         choices=["xarray-concat", "xarray-combine"],
         default="xarray-concat",
@@ -148,10 +133,8 @@ def validate_parsed_args(
         input_files,
         output_path,
         parsed.concat_dim,
-        bool(parsed.keep_tmp_files),
         parsed.concat_method,
         concat_kwargs,
-        parsed.copy_input_files,
         parsed.group_delim,
     )
 
@@ -162,10 +145,8 @@ def run_stitchee(args: list) -> None:
         input_files,
         output_path,
         concat_dim,
-        keep_tmp_files,
         concat_method,
         concat_kwargs,
-        copy_input_files,
         group_delimiter,
     ) = validate_parsed_args(parse_args(args))
     num_inputs = len(input_files)
@@ -183,13 +164,10 @@ def run_stitchee(args: list) -> None:
     stitchee(
         input_files,
         output_path,
-        write_tmp_flat_concatenated=keep_tmp_files,
-        keep_tmp_files=keep_tmp_files,
         concat_method=concat_method,
         concat_dim=concat_dim,
         concat_kwargs=concat_kwargs,
         history_to_append=new_history_json,
-        copy_input_files=copy_input_files,
         group_delimiter=group_delimiter,
     )
     logging.info("STITCHEE complete. Result in %s", output_path)

--- a/concatenator/run_stitchee.py
+++ b/concatenator/run_stitchee.py
@@ -97,7 +97,7 @@ def parse_args(args: list) -> argparse.Namespace:
 
 def validate_parsed_args(
     parsed: argparse.Namespace,
-) -> tuple[list[str], str, str, bool, str, dict, bool, str]:
+) -> tuple[list[str], str, str, str, dict, str]:
     """Perform preliminary validation of the parsed arguments and return them as a tuple."""
     if parsed.verbose:
         logging.basicConfig(level=logging.DEBUG)

--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -172,7 +172,10 @@ def stitchee(
         else:
             raise ValueError(f"Unexpected concatenation method, <{concat_method}>.")
 
-        xr.DataTree.from_dict(combined_dict).to_netcdf(output_file)
+        output_dt = xr.DataTree.from_dict(combined_dict)
+        if history_to_append is not None:
+            output_dt.attrs["history_json"] = history_to_append
+        output_dt.to_netcdf(output_file)
 
         benchmark_log["concatenating"] = time.time() - start_time
 

--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -93,7 +93,6 @@ def stitchee(
         )
 
     try:
-        logger.info("Flattening all input files...")
         xrdatatree_list = []
         concat_dim_order = []
         for i, filepath in enumerate(input_files):
@@ -127,10 +126,10 @@ def stitchee(
 
         tree_dicts = [tree.to_dict() for tree in xrdatatree_list]
         keys_list = [set(t.keys()) for t in tree_dicts]
-        symmetric_diff = reduce(lambda x, y: x ^ y, keys_list)
+        symmetric_diff = any( [kl ^ keys_list[0] for kl in keys_list] )
 
         if symmetric_diff:
-            raise KeyError(f"Datatrees do not have matching Dataset nodes. Nodes that do not match: {symmetric_diff}")
+            raise KeyError(f"Datatrees do not have matching Dataset nodes. Nodes that do not match: {symmetric_diff}.")
 
         # Files are concatenated together (Using XARRAY).
         start_time = time.time()

--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -19,6 +19,7 @@ from concatenator.file_ops import (
 
 default_logger = logging.getLogger(__name__)
 
+
 def stitchee(
     files_to_concat: list[str],
     output_file: str,
@@ -125,10 +126,12 @@ def stitchee(
 
         tree_dicts = [tree.to_dict() for tree in xrdatatree_list]
         keys_list = [set(t.keys()) for t in tree_dicts]
-        symmetric_diff = any( [kl ^ keys_list[0] for kl in keys_list] )
+        symmetric_diff = any([kl ^ keys_list[0] for kl in keys_list])
 
         if symmetric_diff:
-            raise KeyError(f"Datatrees do not have matching Dataset nodes. Nodes that do not match: {symmetric_diff}.")
+            raise KeyError(
+                f"Datatrees do not have matching Dataset nodes. Nodes that do not match: {symmetric_diff}."
+            )
 
         # Files are concatenated together (Using XARRAY).
         start_time = time.time()
@@ -147,7 +150,7 @@ def stitchee(
 
         if concat_method == "xarray-concat":
             combined_dict = {
-                kk : xr.concat(
+                kk: xr.concat(
                     [tree_dict[kk] for tree_dict in tree_dicts],
                     data_vars="minimal",
                     coords="minimal",
@@ -159,7 +162,7 @@ def stitchee(
 
         elif concat_method == "xarray-combine":
             combined_dict = {
-                kk : xr.combine_by_coords(
+                kk: xr.combine_by_coords(
                     [tree_dict[kk] for tree_dict in tree_dicts],
                     data_vars="minimal",
                     coords="minimal",

--- a/concatenator/stitchee.py
+++ b/concatenator/stitchee.py
@@ -7,7 +7,6 @@ import shutil
 import time
 from logging import Logger
 from warnings import warn
-from functools import reduce
 
 import xarray as xr
 

--- a/tests/integration/test_concat_with_subsetting_first.py
+++ b/tests/integration/test_concat_with_subsetting_first.py
@@ -17,6 +17,7 @@ def test_concat_with_subsetting_first(temp_output_dir):
             "stop": dt.datetime(2024, 5, 13, 20, 0, 0),
         },
         spatial=BBox(-130, 30, -115, 35),
+        extend=False,
         concatenate=False,
     )
     if not request.is_valid():
@@ -40,8 +41,6 @@ def test_concat_with_subsetting_first(temp_output_dir):
         ),
         concat_dim="mirror_step",
         concat_method="xarray-concat",
-        write_tmp_flat_concatenated=True,
-        keep_tmp_files=True,
     )
 
     assert output_path

--- a/tests/integration/test_history_construction.py
+++ b/tests/integration/test_history_construction.py
@@ -23,8 +23,6 @@ def test_construct_and_append_history_for_sample_concatenation(
     output_path = stitchee(
         files_to_concat=prepared_input_files,
         output_file=output_path,
-        write_tmp_flat_concatenated=True,
-        keep_tmp_files=True,
         concat_method="xarray-concat",
         history_to_append=new_history_json,
         concat_dim="step",

--- a/tests/local/test_stitchee_with_local_files.py
+++ b/tests/local/test_stitchee_with_local_files.py
@@ -36,8 +36,6 @@ class TestConcat:
         output_path = stitchee(
             files_to_concat=prepared_input_files,
             output_file=output_path,
-            write_tmp_flat_concatenated=True,
-            keep_tmp_files=True,
             concat_method=concat_method,
             concat_dim=record_dim_name,
             concat_kwargs=concat_kwargs,

--- a/tests/unit/test_run_stitchee.py
+++ b/tests/unit/test_run_stitchee.py
@@ -37,7 +37,6 @@ class TestBatching:
             path_str(granules_path, "TEMPO_NO2_L2_V03_20240601T210934Z_S012G01_subsetted.nc4"),
             path_str(granules_path, "TEMPO_NO2_L2_V03_20240601T211614Z_S012G02_subsetted.nc4"),
             path_str(granules_path, "TEMPO_NO2_L2_V03_20240601T212254Z_S012G03_subsetted.nc4"),
-            "--copy_input_files",
             "--verbose",
             "-o",
             path_str(temp_output_dir, "test_run_stitchee_output.nc"),
@@ -54,7 +53,6 @@ class TestBatching:
         test_args = [
             concatenator.run_stitchee.__file__,
             str(granules_path),
-            "--copy_input_files",
             "--verbose",
             "-o",
             path_str(temp_output_dir, "test_run_stitchee_output.nc"),
@@ -71,7 +69,6 @@ class TestBatching:
         test_args = [
             concatenator.run_stitchee.__file__,
             path_str(granules_path, "TEMPO_NO2_L2_V03_20240601T210934Z_S012G01_subsetted.nc4"),
-            "--copy_input_files",
             "--verbose",
             "-o",
             path_str(temp_output_dir, "test_run_stitchee_output.nc"),
@@ -90,7 +87,6 @@ class TestBatching:
         test_args = [
             concatenator.run_stitchee.__file__,
             str(text_file_with_three_paths),
-            "--copy_input_files",
             "--verbose",
             "-o",
             path_str(temp_output_dir, "test_run_stitchee_output.nc"),


### PR DESCRIPTION
GitHub Issue: #138

### Description

Recent l2ss-py update to 3.0.0 with newly released `xarray.DataTree` extension duplicates dimensions inside the netCDF groups. These duplicated dimensions break stitchee algorithm which flattens them into independent variables. Migrating stitchee logic to `xarray.DataTree` will resolve the issue.

### Local test steps

* replaced manual flattening and regrouping methods with `xarray.DataTree` methods.
* deployed updated stitchee image in local Harmony
* ran local SAMBAH requests for TEMPO collections

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [ ] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--280.org.readthedocs.build/en/280/

<!-- readthedocs-preview stitchee end -->