### PR TITLE
Feature/issue 265 update with NoDataException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update the default python version from 3.10 to 3.12 ([#284](https://github.com/nasa/stitchee/pull/284))([**@danielfromearth**](https://github.com/danielfromearth))
 - flip package and module names, so package is "stitchee" ([#285](https://github.com/nasa/stitchee/pull/285))([**@danielfromearth**](https://github.com/danielfromearth))
 - add --no-verify to git push when committing version bump ([#286](https://github.com/nasa/stitchee/pull/286))([**@danielfromearth**](https://github.com/danielfromearth))
+- update to handle `NoDataException` from `l2ss-py` ([#288](https://github.com/nasa/stitchee/pull/288))([**@ank1m**](https://github.com/ank1m))
 
 ## [1.6.1] - 2024-11-27
 

--- a/stitchee/file_ops.py
+++ b/stitchee/file_ops.py
@@ -114,11 +114,6 @@ def validate_workable_files(
         except Exception as e:
             logger.debug("Error opening %s as netCDF: %s", file, e)
 
-    # addressing GitHub issue 153: If all files are empty, return the first file
-    if len(workable_files) == 0 and files:
-        logger.info("All input files are empty. Using first file: %s", files[0])
-        workable_files.append(files[0])
-
     return workable_files, len(workable_files)
 
 

--- a/tests/unit/test_file_ops.py
+++ b/tests/unit/test_file_ops.py
@@ -44,6 +44,15 @@ def test_validate_bad_non_existent_input_path():
         validate_input_path([])
 
 
+def test_dataset_with_single_empty_input_file():
+    """Ensure that empty input files are filtered out and are not considered as valid input"""
+    files_to_concat = [
+        data_for_tests_dir / "unit-test-data" / "TEMPO_NO2_L2_V03_20240328T154353Z_S008G01.nc4"
+    ]
+    workable_files, number_of_workable_files = validate_workable_files(files_to_concat)
+    assert number_of_workable_files == 0
+
+
 def test_dataset_with_singleton_null_values_is_identified_as_empty():
     """Ensure that a dataset with only null arrays with 1-length dimensions is identified as empty."""
     singleton_null_values_file = (

--- a/tests/unit/test_file_ops.py
+++ b/tests/unit/test_file_ops.py
@@ -44,15 +44,6 @@ def test_validate_bad_non_existent_input_path():
         validate_input_path([])
 
 
-def test_dataset_with_single_empty_input_file():
-    """Ensure that a dataset with a single empty input file is propagating empty granule to the output"""
-    files_to_concat = [
-        data_for_tests_dir / "unit-test-data" / "TEMPO_NO2_L2_V03_20240328T154353Z_S008G01.nc4"
-    ]
-    workable_files, number_of_workable_files = validate_workable_files(files_to_concat)
-    assert number_of_workable_files == 1
-
-
 def test_dataset_with_singleton_null_values_is_identified_as_empty():
     """Ensure that a dataset with only null arrays with 1-length dimensions is identified as empty."""
     singleton_null_values_file = (


### PR DESCRIPTION
GitHub Issue: #265

### Description

Removing the piece of code that propagates empty granule to output when all input files are empty. This situation should never occur in Harmony after `NoDataException` was introduced in the recent update.

### Local test steps

* tested in local Harmony that the removing of the code does not break stitchee operation

### Overview of integration done

* tested in local Harmony that the removing of the code does not break stitchee operation


## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] ~Documentation updated (if needed).~


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--288.org.readthedocs.build/en/288/

<!-- readthedocs-preview stitchee end -->