### PR TITLE
Feature/Issue 298: Handle variables with duplicate dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Handle variables with duplicate dimensions ([#299](https://github.com/nasa/stitchee/pull/299))([**@ank1m**](https://github.com/ank1m))
+- Handle non-concatenating variables of the same name for potential conflict ([#299](https://github.com/nasa/stitchee/pull/299))([**@ank1m**](https://github.com/ank1m))
+
 ## [1.7.0] - 2025-07-07
 
 ### Changed

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -235,17 +235,19 @@ def concat_datasets(datasets: list[xr.DataSet], concat_dim: str, concat_kwargs: 
     # Find all variables with duplicate dimensions using first dataset
     duplicate_variables = find_variables_with_duplicate_dimensions(datasets[0])
 
-    # Concatenate datarrays manually for each variable with duplicate dimensions
-    if duplicate_variables:
-        cleaned_datasets = [dataset.drop_vars(duplicate_variables) for dataset in datasets]
-        concatenated_dataset = xr.concat(cleaned_datasets, dim=concat_dim, **base_kwargs)
-        for variable in duplicate_variables:
-            dataarray = concat_manually(
-                [dataset[variable] for dataset in datasets], concat_dim, concat_kwargs
-            )
-            concatenated_dataset = concatenated_dataset.assign({variable: dataarray})
-    else:
-        concatenated_dataset = xr.concat(datasets, dim=concat_dim, **base_kwargs)
+    if not duplicate_variables:
+        return xr.concat(datasets, dim=concat_dim, **base_kwargs)
+        
+    # Concatenate datarrays first without duplicate dimensions
+    clean_datasets = [dataset.drop_vars(duplicate_variables) for dataset in datasets]
+    concatenated_dataset = xr.concat(clean_datasets, dim=concat_dim, **base_kwargs)
+    
+    # Process each duplicate variable separately
+    for variable in duplicate_variables:
+        dataarray = concat_with_duplicate_dims(
+            [dataset[variable] for dataset in datasets], concat_dim, concat_kwargs
+        )
+        concatenated_dataset = concatenated_dataset.assign({variable: dataarray})
 
     return concatenated_dataset
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -200,9 +200,8 @@ def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, 
     # data_vars must be "all" when concatenating because there is only one data_var, DataArray itself
     base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs, "data_vars": "all"}
 
-    # construct a list of dataarrays with repeated dimensions renamed
+    # Rename duplicate dimensions, then concatenate
     new_dataarrays = [rename_to_uniq_dimensions(da) for da in dataarrays]
-    # concatenate the manually constructed dataarrays
     concatenated_dataarray = xr.concat(new_dataarrays, dim=concat_dim, **base_kwargs)
 
     # reconstruct the old list of dimensions and coordinates with repeated dims

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -226,7 +226,9 @@ def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, 
     return dataarray_back
 
 
-def composite_concat(datasets, concat_dim: str, concat_kwargs: dict):
+def concat_datasets(datasets: list[xr.DataSet], concat_dim: str, concat_kwargs: dict):
+    """Concatenate datasets, handling variables with duplicate dimensions specially."""
+
     # Build base kwargs
     base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs}
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -261,7 +261,7 @@ def _create_concat_function(concat_method: str, concat_dim: str, concat_kwargs: 
 
     # Create appropriate function
     if concat_method == "xarray-concat":
-        return partial(composite_concat, concat_dim=concat_dim, concat_kwargs=concat_kwargs)
+        return partial(concat_datasets, concat_dim=concat_dim, concat_kwargs=concat_kwargs)
     else:  # concat_method == "xarray-combine"
         return partial(xr.combine_by_coords, **base_kwargs)
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -140,7 +140,7 @@ def validate_concat_method_and_dim(concat_method: str, concat_dim: str | None = 
         )
 
 
-def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
+def _find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
     """Return variable names that have repeated dimensions."""
     duplicate_variables = [
         varname
@@ -151,18 +151,18 @@ def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
     return duplicate_variables
 
 
-def rename_to_uniq_dimensions(dataarray: xr.DataArray):
+def _rename_to_uniq_dimensions(dataarray: xr.DataArray):
     """Make duplicate dimension names unique by adding numeric prefixes.
-        
+
     Returns
     -------
     xr.DataArray
         New DataArray with unique dimension names and updated coordinates.
-        
+
     Examples
     --------
     >>> arr = xr.DataArray([[1, 2], [3, 4]], dims=['x', 'x'])
-    >>> result = rename_to_uniq_dimensions(arr)
+    >>> result = _rename_to_uniq_dimensions(arr)
     >>> result.dims
     ('x', '1___x')
     """
@@ -191,9 +191,11 @@ def rename_to_uniq_dimensions(dataarray: xr.DataArray):
     return new_dataarray
 
 
-def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, concat_kwargs: dict):
+def _concat_with_duplicate_dims(
+    dataarrays: list[xr.DataArray], concat_dim: str, concat_kwargs: dict
+):
     """Concatenate DataArrays that may have duplicate dimension names.
-    
+
     Temporarily renames duplicate dimensions, concatenates, then restores original names.
     """
     # Prepare concatenation settings
@@ -201,7 +203,7 @@ def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, 
     base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs, "data_vars": "all"}
 
     # Rename duplicate dimensions, then concatenate
-    new_dataarrays = [rename_to_uniq_dimensions(da) for da in dataarrays]
+    new_dataarrays = [_rename_to_uniq_dimensions(da) for da in dataarrays]
     concatenated_dataarray = xr.concat(new_dataarrays, dim=concat_dim, **base_kwargs)
 
     # reconstruct the old list of dimensions and coordinates with repeated dims
@@ -226,25 +228,25 @@ def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, 
     return dataarray_back
 
 
-def concat_datasets(datasets: list[xr.DataSet], concat_dim: str, concat_kwargs: dict):
+def _concat_datasets(datasets: list[xr.DataSet], concat_dim: str, concat_kwargs: dict):
     """Concatenate datasets, handling variables with duplicate dimensions specially."""
 
     # Build base kwargs
     base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs}
 
     # Find all variables with duplicate dimensions using first dataset
-    duplicate_variables = find_variables_with_duplicate_dimensions(datasets[0])
+    duplicate_variables = _find_variables_with_duplicate_dimensions(datasets[0])
 
     if not duplicate_variables:
         return xr.concat(datasets, dim=concat_dim, **base_kwargs)
-        
+
     # Concatenate datarrays first without duplicate dimensions
     clean_datasets = [dataset.drop_vars(duplicate_variables) for dataset in datasets]
     concatenated_dataset = xr.concat(clean_datasets, dim=concat_dim, **base_kwargs)
-    
+
     # Process each duplicate variable separately
     for variable in duplicate_variables:
-        dataarray = concat_with_duplicate_dims(
+        dataarray = _concat_with_duplicate_dims(
             [dataset[variable] for dataset in datasets], concat_dim, concat_kwargs
         )
         concatenated_dataset = concatenated_dataset.assign({variable: dataarray})
@@ -261,7 +263,7 @@ def _create_concat_function(concat_method: str, concat_dim: str, concat_kwargs: 
 
     # Create appropriate function
     if concat_method == "xarray-concat":
-        return partial(concat_datasets, concat_dim=concat_dim, concat_kwargs=concat_kwargs)
+        return partial(_concat_datasets, concat_dim=concat_dim, concat_kwargs=concat_kwargs)
     else:  # concat_method == "xarray-combine"
         return partial(xr.combine_by_coords, **base_kwargs)
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -191,11 +191,14 @@ def rename_to_uniq_dimensions(dataarray: xr.DataArray):
     return new_dataarray
 
 
-def concat_manually(dataarrays, concat_dim: str, concat_kwargs: dict):
-    # Build base kwargs
-    base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs}
-    # data_vars must be "all" when concatenating DataArrays because there is only one data_var, DataArray itself
-    base_kwargs.update({"data_vars": "all"})
+def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, concat_kwargs: dict):
+    """Concatenate DataArrays that may have duplicate dimension names.
+    
+    Temporarily renames duplicate dimensions, concatenates, then restores original names.
+    """
+    # Prepare concatenation settings
+    # data_vars must be "all" when concatenating because there is only one data_var, DataArray itself
+    base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs, "data_vars": "all"}
 
     # construct a list of dataarrays with repeated dimensions renamed
     new_dataarrays = [rename_to_uniq_dimensions(da) for da in dataarrays]

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -151,8 +151,21 @@ def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
     return duplicate_variables
 
 
-def rename_to_uniq_dimensions(dataarray):
-    # find the repetition numbers for all dimensions
+def rename_to_uniq_dimensions(dataarray: xr.DataArray):
+    """Make duplicate dimension names unique by adding numeric prefixes.
+        
+    Returns
+    -------
+    xr.DataArray
+        New DataArray with unique dimension names and updated coordinates.
+        
+    Examples
+    --------
+    >>> arr = xr.DataArray([[1, 2], [3, 4]], dims=['x', 'x'])
+    >>> result = rename_to_uniq_dimensions(arr)
+    >>> result.dims
+    ('x', '1___x')
+    """
     iduplicates = [idim - dataarray.dims.index(dim) for idim, dim in enumerate(dataarray.dims)]
     # rename repeated dimensions with a prefix to each repeated dimension
     new_dims = [

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -146,10 +146,7 @@ def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
     duplicate_variables = [
         varname
         for varname in dataset.variables
-        if (
-            (dims := dataset[varname].dims)
-            and (any(idim != dims.index(dim) for idim, dim in enumerate(dims)))
-        )
+        if (dims := dataset[varname].dims) and len(dims) != len(set(dims))
     ]
 
     return duplicate_variables

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -206,10 +206,9 @@ def concat_with_duplicate_dims(dataarrays: list[xr.DataArray], concat_dim: str, 
 
     # reconstruct the old list of dimensions and coordinates with repeated dims
     old_dims = [dim.split("___", 1)[-1] for dim in concatenated_dataarray.dims]
-    dim_tuple = list(zip(old_dims, concatenated_dataarray.dims))
     old_coords = {
         old_dim: concatenated_dataarray.coords[new_dim].rename({new_dim: old_dim})
-        for old_dim, new_dim in dim_tuple
+        for old_dim, new_dim in zip(old_dims, concatenated_dataarray.dims)
         if new_dim in concatenated_dataarray.coords
     }
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -20,7 +20,8 @@ from stitchee.file_ops import (
 
 # Module constants
 SUPPORTED_CONCAT_METHODS = ("xarray-concat", "xarray-combine")
-DEFAULT_XARRAY_SETTINGS = {"data_vars": "minimal", "coords": "minimal"}
+# include compat="override" to handle inconsistent values of gas_names in O3PROF collection
+DEFAULT_XARRAY_SETTINGS = {"data_vars": "minimal", "coords": "minimal", "compat": "override"}
 DATATREE_OPEN_OPTIONS = {
     "decode_times": False,
     "decode_coords": False,
@@ -139,6 +140,101 @@ def validate_concat_method_and_dim(concat_method: str, concat_dim: str | None = 
         )
 
 
+def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
+    # find variables with duplicate dimensions
+    # by comparing dimension's index with its first occurrence
+    duplicate_variables = [
+        varname
+        for varname in dataset.variables
+        if (
+            (dims := dataset[varname].dims) and (
+                any(idim != dims.index(dim) for idim, dim in enumerate(dims))
+                or ('a' in varname and 'mirror_step' in dims)
+            )
+        )
+    ]
+
+    return duplicate_variables
+
+
+def rename_to_uniq_dimensions(dataarray):
+    # find the repetition numbers for all dimensions
+    iduplicates = [idim-dataarray.dims.index(dim) for idim,dim in enumerate(dataarray.dims)]
+    # rename repeated dimensions with a prefix to each repeated dimension
+    new_dims = [dim if idup==0 else f'{idup}___{dim}' for idup,dim in zip(iduplicates, dataarray.dims)]
+    dim_tuple = list(zip(dataarray.dims, new_dims))
+    # update coordinates with newly renamed dimensions
+    new_coords = {
+        new_dim: dataarray.coords[old_dim].rename({old_dim: new_dim})
+        for old_dim, new_dim in dim_tuple
+        if old_dim in dataarray.coords
+    }
+
+    # construct new DataArray with repeated dimensions
+    new_dataarray = xr.DataArray(
+        dataarray.to_numpy(),
+        dims = new_dims,
+        coords = new_coords,
+        name = dataarray.name,
+        attrs = dataarray.attrs,
+    )
+
+    return new_dataarray
+
+
+def concat_manually(dataarrays, concat_dim: str, concat_kwargs: dict):
+    # Build base kwargs
+    base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs}
+    # data_vars must be "all" when concatenating DataArrays because there is only one data_var, DataArray itself
+    base_kwargs.update({"data_vars": "all"})
+
+    # construct a list of dataarrays with repeated dimensions renamed
+    new_dataarrays = [rename_to_uniq_dimensions(da) for da in dataarrays]
+    # concatenate the manually constructed dataarrays
+    concatenated_dataarray = xr.concat(new_dataarrays, dim=concat_dim, **base_kwargs)
+
+    # reconstruct the old list of dimensions and coordinates with repeated dims
+    old_dims = [dim.split('___',1)[-1] for dim in concatenated_dataarray.dims]
+    dim_tuple = list(zip(old_dims, concatenated_dataarray.dims))
+    old_coords = {
+        old_dim: concatenated_dataarray.coords[new_dim].rename({new_dim: old_dim})
+        for old_dim, new_dim in dim_tuple
+        if new_dim in concatenated_dataarray.coords
+    }
+
+    # construct DataArray again with original dimension schema
+    dataarray_back = xr.DataArray(  
+        concatenated_dataarray.to_numpy(),
+        dims = old_dims,
+        coords = old_coords,
+        name = concatenated_dataarray.name,
+        attrs = concatenated_dataarray.attrs,
+    )
+    # preserve encoding for storage in NetCDF4
+    dataarray_back.encoding = dataarrays[0].encoding
+
+    return dataarray_back
+
+
+def composite_concat(datasets, concat_dim: str, concat_kwargs: dict):
+    # Build base kwargs
+    base_kwargs = {**DEFAULT_XARRAY_SETTINGS, **concat_kwargs}
+
+    # Find all variables with duplicate dimensions using first dataset
+    duplicate_variables = find_variables_with_duplicate_dimensions(datasets[0])
+
+    # Concatenate datarrays manually for each variable with duplicate dimensions
+    if duplicate_variables:
+        cleaned_datasets = [dataset.drop_vars(duplicate_variables) for dataset in datasets]
+        concatenated_dataset = xr.concat(cleaned_datasets, dim=concat_dim, **base_kwargs)
+        for variable in duplicate_variables:
+           dataarray = concat_manually([dataset[variable] for dataset in datasets], concat_dim, concat_kwargs)
+           concatenated_dataset = concatenated_dataset.assign({variable: dataarray})
+    else:
+        concatenated_dataset = xr.concat(datasets, dim=concat_dim, **base_kwargs)
+
+    return concatenated_dataset
+
 def _create_concat_function(concat_method: str, concat_dim: str, concat_kwargs: dict) -> Callable:
     """Create concatenation function after validating method and dimension requirements."""
     validate_concat_method_and_dim(concat_method, concat_dim)
@@ -148,7 +244,7 @@ def _create_concat_function(concat_method: str, concat_dim: str, concat_kwargs: 
 
     # Create appropriate function
     if concat_method == "xarray-concat":
-        return partial(xr.concat, dim=concat_dim, **base_kwargs)
+        return partial(composite_concat, concat_dim=concat_dim, concat_kwargs=concat_kwargs)
     else:  # concat_method == "xarray-combine"
         return partial(xr.combine_by_coords, **base_kwargs)
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -141,8 +141,7 @@ def validate_concat_method_and_dim(concat_method: str, concat_dim: str | None = 
 
 
 def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
-    # find variables with duplicate dimensions
-    # by comparing dimension's index with its first occurrence
+    """Return variable names that have repeated dimensions."""
     duplicate_variables = [
         varname
         for varname in dataset.variables

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -149,7 +149,6 @@ def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
         if (
             (dims := dataset[varname].dims) and (
                 any(idim != dims.index(dim) for idim, dim in enumerate(dims))
-                or ('a' in varname and 'mirror_step' in dims)
             )
         )
     ]

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -147,9 +147,8 @@ def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
         varname
         for varname in dataset.variables
         if (
-            (dims := dataset[varname].dims) and (
-                any(idim != dims.index(dim) for idim, dim in enumerate(dims))
-            )
+            (dims := dataset[varname].dims)
+            and (any(idim != dims.index(dim) for idim, dim in enumerate(dims)))
         )
     ]
 
@@ -158,9 +157,11 @@ def find_variables_with_duplicate_dimensions(dataset: xr.DataSet):
 
 def rename_to_uniq_dimensions(dataarray):
     # find the repetition numbers for all dimensions
-    iduplicates = [idim-dataarray.dims.index(dim) for idim,dim in enumerate(dataarray.dims)]
+    iduplicates = [idim - dataarray.dims.index(dim) for idim, dim in enumerate(dataarray.dims)]
     # rename repeated dimensions with a prefix to each repeated dimension
-    new_dims = [dim if idup==0 else f'{idup}___{dim}' for idup,dim in zip(iduplicates, dataarray.dims)]
+    new_dims = [
+        dim if idup == 0 else f"{idup}___{dim}" for idup, dim in zip(iduplicates, dataarray.dims)
+    ]
     dim_tuple = list(zip(dataarray.dims, new_dims))
     # update coordinates with newly renamed dimensions
     new_coords = {
@@ -172,10 +173,10 @@ def rename_to_uniq_dimensions(dataarray):
     # construct new DataArray with repeated dimensions
     new_dataarray = xr.DataArray(
         dataarray.to_numpy(),
-        dims = new_dims,
-        coords = new_coords,
-        name = dataarray.name,
-        attrs = dataarray.attrs,
+        dims=new_dims,
+        coords=new_coords,
+        name=dataarray.name,
+        attrs=dataarray.attrs,
     )
 
     return new_dataarray
@@ -193,7 +194,7 @@ def concat_manually(dataarrays, concat_dim: str, concat_kwargs: dict):
     concatenated_dataarray = xr.concat(new_dataarrays, dim=concat_dim, **base_kwargs)
 
     # reconstruct the old list of dimensions and coordinates with repeated dims
-    old_dims = [dim.split('___',1)[-1] for dim in concatenated_dataarray.dims]
+    old_dims = [dim.split("___", 1)[-1] for dim in concatenated_dataarray.dims]
     dim_tuple = list(zip(old_dims, concatenated_dataarray.dims))
     old_coords = {
         old_dim: concatenated_dataarray.coords[new_dim].rename({new_dim: old_dim})
@@ -202,12 +203,12 @@ def concat_manually(dataarrays, concat_dim: str, concat_kwargs: dict):
     }
 
     # construct DataArray again with original dimension schema
-    dataarray_back = xr.DataArray(  
+    dataarray_back = xr.DataArray(
         concatenated_dataarray.to_numpy(),
-        dims = old_dims,
-        coords = old_coords,
-        name = concatenated_dataarray.name,
-        attrs = concatenated_dataarray.attrs,
+        dims=old_dims,
+        coords=old_coords,
+        name=concatenated_dataarray.name,
+        attrs=concatenated_dataarray.attrs,
     )
     # preserve encoding for storage in NetCDF4
     dataarray_back.encoding = dataarrays[0].encoding
@@ -227,12 +228,15 @@ def composite_concat(datasets, concat_dim: str, concat_kwargs: dict):
         cleaned_datasets = [dataset.drop_vars(duplicate_variables) for dataset in datasets]
         concatenated_dataset = xr.concat(cleaned_datasets, dim=concat_dim, **base_kwargs)
         for variable in duplicate_variables:
-           dataarray = concat_manually([dataset[variable] for dataset in datasets], concat_dim, concat_kwargs)
-           concatenated_dataset = concatenated_dataset.assign({variable: dataarray})
+            dataarray = concat_manually(
+                [dataset[variable] for dataset in datasets], concat_dim, concat_kwargs
+            )
+            concatenated_dataset = concatenated_dataset.assign({variable: dataarray})
     else:
         concatenated_dataset = xr.concat(datasets, dim=concat_dim, **base_kwargs)
 
     return concatenated_dataset
+
 
 def _create_concat_function(concat_method: str, concat_dim: str, concat_kwargs: dict) -> Callable:
     """Create concatenation function after validating method and dimension requirements."""

--- a/tests/unit/test_duplicated_dimensions.py
+++ b/tests/unit/test_duplicated_dimensions.py
@@ -1,0 +1,87 @@
+import pytest
+import numpy as np
+import xarray as xr
+
+from stitchee.concatenate import (
+    _find_variables_with_duplicate_dimensions,
+    _rename_to_uniq_dimensions,
+    _concat_with_duplicate_dims,
+)
+
+
+@pytest.fixture
+def dataset():
+    nstep, nxtrack, nlayer, nlevel = 4, 5, 6, 3
+
+    # Coordinate labels
+    coords = {
+        "mirror_step": np.arange(nstep),
+        "xtrack": np.arange(nxtrack),
+        "layer": np.arange(nlayer),
+        "level": np.arange(nlevel),
+    }
+
+    # Variables
+    data_vars = {
+        # 2D variable
+        "var2d": (("mirror_step", "xtrack"), np.random.rand(nstep, nxtrack)),
+        # 3D variables
+        "var3d_a": (("mirror_step", "xtrack", "layer"), np.random.rand(nstep, nxtrack, nlayer)),
+        "var3d_b": (("mirror_step", "layer", "layer"), np.random.rand(nstep, nlayer, nlayer)),
+        "var3d_c": (("mirro_step", "xtrack", "level"), np.random.rand(nstep, nxtrack, nlevel)),
+        # 4D variables
+        "var4d_a": (
+            ("mirror_step", "xtrack", "layer", "layer"),
+            np.random.rand(nstep, nxtrack, nlayer, nlayer),
+        ),
+        "var4d_b": (
+            ("mirror_step", "xtrack", "layer", "level"),
+            np.random.rand(nstep, nxtrack, nlayer, nlevel),
+        ),
+    }
+
+    # Build dataset
+    return xr.Dataset(data_vars=data_vars, coords=coords)
+
+
+def test_finding_variables_with_duplicate_dimensions(dataset):
+    duplicate_variables = _find_variables_with_duplicate_dimensions(dataset)
+    assert duplicate_variables == ["var3d_b", "var4d_a"]
+
+
+def test_renaming_to_uniq_dimensions(dataset):
+    new_dataset4d = _rename_to_uniq_dimensions(dataset["var4d_a"])
+    assert new_dataset4d.dims == ("mirror_step", "xtrack", "layer", "1___layer")
+
+
+def test_concat_with_duplicate_dims():
+    data4d_1 = np.random.rand(20, 30, 5, 5)
+    da_1 = xr.DataArray(
+        data4d_1,
+        dims=("mirror_step", "xtrack", "layer", "layer"),
+        coords={"mirror_step": np.arange(20), "xtrack": np.arange(30), "layer": np.arange(5)},
+        name="var4d",
+    )
+
+    data4d_2 = np.random.rand(11, 30, 5, 5)
+    da_2 = xr.DataArray(
+        data4d_2,
+        dims=("mirror_step", "xtrack", "layer", "layer"),
+        coords={"mirror_step": np.arange(20, 31), "xtrack": np.arange(30), "layer": np.arange(5)},
+        name="var4d",
+    )
+
+    total_da = xr.DataArray(
+        np.concatenate([data4d_1, data4d_2], axis=0),
+        dims=("mirror_step", "xtrack", "layer", "layer"),
+        coords={"mirror_step": np.arange(31), "xtrack": np.arange(30), "layer": np.arange(5)},
+        name="var4d",
+    )
+
+    concat_kwargs = {"data_vars": "minimal", "coords": "minimal", "compat": "override"}
+
+    concatenated_da = _concat_with_duplicate_dims(
+        [da_1, da_2], concat_dim="mirror_step", concat_kwargs=concat_kwargs
+    )
+
+    assert total_da.identical(concatenated_da)

--- a/tests/unit/test_duplicated_dimensions.py
+++ b/tests/unit/test_duplicated_dimensions.py
@@ -87,28 +87,38 @@ def test_concat_with_duplicate_dims():
 
     assert total_da.identical(concatenated_da)
 
+
 def test_concat_datasets():
     data2d_1 = np.random.rand(20, 30)
     data4d_1 = np.random.rand(20, 30, 5, 5)
-    ds_1 = xr.Dataset({
+    ds_1 = xr.Dataset(
+        {
             "var2d": (("mirror_step", "xtrack"), data2d_1),
-            "var4d": (("mirror_step", "xtrack", "layer", "layer"), data4d_1)
+            "var4d": (("mirror_step", "xtrack", "layer", "layer"), data4d_1),
         },
         coords={"mirror_step": np.arange(20), "xtrack": np.arange(30), "layer": np.arange(5)},
     )
 
     data2d_2 = np.random.rand(11, 30)
     data4d_2 = np.random.rand(11, 30, 5, 5)
-    ds_2 = xr.Dataset({
+    ds_2 = xr.Dataset(
+        {
             "var2d": (("mirror_step", "xtrack"), data2d_2),
-            "var4d": (("mirror_step", "xtrack", "layer", "layer"), data4d_2)
+            "var4d": (("mirror_step", "xtrack", "layer", "layer"), data4d_2),
         },
-        coords={"mirror_step": np.arange(20,31), "xtrack": np.arange(30), "layer": np.arange(5)},
+        coords={"mirror_step": np.arange(20, 31), "xtrack": np.arange(30), "layer": np.arange(5)},
     )
 
-    total_ds = xr.Dataset({
-            "var2d": (("mirror_step", "xtrack"), np.concatenate([data2d_1, data2d_2], axis=0),),
-            "var4d": (("mirror_step", "xtrack", "layer", "layer"), np.concatenate([data4d_1, data4d_2], axis=0),)
+    total_ds = xr.Dataset(
+        {
+            "var2d": (
+                ("mirror_step", "xtrack"),
+                np.concatenate([data2d_1, data2d_2], axis=0),
+            ),
+            "var4d": (
+                ("mirror_step", "xtrack", "layer", "layer"),
+                np.concatenate([data4d_1, data4d_2], axis=0),
+            ),
         },
         coords={"mirror_step": np.arange(31), "xtrack": np.arange(30), "layer": np.arange(5)},
     )

--- a/tests/unit/test_duplicated_dimensions.py
+++ b/tests/unit/test_duplicated_dimensions.py
@@ -1,11 +1,11 @@
-import pytest
 import numpy as np
+import pytest
 import xarray as xr
 
 from stitchee.concatenate import (
+    _concat_with_duplicate_dims,
     _find_variables_with_duplicate_dimensions,
     _rename_to_uniq_dimensions,
-    _concat_with_duplicate_dims,
 )
 
 

--- a/tests/unit/test_duplicated_dimensions.py
+++ b/tests/unit/test_duplicated_dimensions.py
@@ -3,6 +3,7 @@ import pytest
 import xarray as xr
 
 from stitchee.concatenate import (
+    _concat_datasets,
     _concat_with_duplicate_dims,
     _find_variables_with_duplicate_dimensions,
     _rename_to_uniq_dimensions,
@@ -85,3 +86,37 @@ def test_concat_with_duplicate_dims():
     )
 
     assert total_da.identical(concatenated_da)
+
+def test_concat_datasets():
+    data2d_1 = np.random.rand(20, 30)
+    data4d_1 = np.random.rand(20, 30, 5, 5)
+    ds_1 = xr.Dataset({
+            "var2d": (("mirror_step", "xtrack"), data2d_1),
+            "var4d": (("mirror_step", "xtrack", "layer", "layer"), data4d_1)
+        },
+        coords={"mirror_step": np.arange(20), "xtrack": np.arange(30), "layer": np.arange(5)},
+    )
+
+    data2d_2 = np.random.rand(11, 30)
+    data4d_2 = np.random.rand(11, 30, 5, 5)
+    ds_2 = xr.Dataset({
+            "var2d": (("mirror_step", "xtrack"), data2d_2),
+            "var4d": (("mirror_step", "xtrack", "layer", "layer"), data4d_2)
+        },
+        coords={"mirror_step": np.arange(20,31), "xtrack": np.arange(30), "layer": np.arange(5)},
+    )
+
+    total_ds = xr.Dataset({
+            "var2d": (("mirror_step", "xtrack"), np.concatenate([data2d_1, data2d_2], axis=0),),
+            "var4d": (("mirror_step", "xtrack", "layer", "layer"), np.concatenate([data4d_1, data4d_2], axis=0),)
+        },
+        coords={"mirror_step": np.arange(31), "xtrack": np.arange(30), "layer": np.arange(5)},
+    )
+
+    concat_kwargs = {"data_vars": "minimal", "coords": "minimal", "compat": "override"}
+
+    concatenated_ds = _concat_datasets(
+        [ds_1, ds_2], concat_dim="mirror_step", concat_kwargs=concat_kwargs
+    )
+
+    assert total_ds.identical(concatenated_ds)


### PR DESCRIPTION
GitHub Issue: #298, #297

### Descriptions

- TEMPO O3PROF collection includes the variable `ozone_averaging_kernel`, which uses the coordinate layer twice in its dimensions because it encodes correlations between different atmospheric layers. `xarray` does not support duplicate dimensions within a variable, and attempts to concatenate the datasets with this variable result in failure.
- By default, `xr.concat` propagates variables that do not depend on the concatenation dimension to the output file if they are identical across inputs, but raises an error if they differ. In TEMPO O3PROF Level-2 collection, files have `support_data/other_gas_names` variable, which varies from granule to granule, raising an error during concatenation in stitchee.

### Solution

- `xarray` supports the definition of data variables that contain duplicate dimension names, but it does not support performing operations on such variables. A practical workaround is:

> - **Rebuild variables with unique dimension names** – for each variable that has duplicate dimensions, manually construct an equivalent DataArray where the dimensions are renamed to ensure uniqueness.
> - **Concatenate safely** – use `xr.concat` on these newly constructed DataArray objects; this works because their dimensions are no longer duplicated.
> - **Restore original names** – create a copy of the concatenated DataArray and rename the dimensions back to their original (duplicated) names.
> - **Integrate into the dataset** – assign this processed DataArray back into the concatenated Dataset, which can then be written out to a NetCDF4 file.

- add `{compat: "override"}` to Default xarray options to handle variables that are not being concatenated but also are not consistent from granule to granule.

### Local test steps

- Deploy new stitchee in local Harmony
- For testing purposes, randomly select a subset of variables to process with the new manual procedure in local Harmony
- Compare the output files with the output files from the equivalent request in UAT Harmony
- `xr.DataTree.equals` confirmed that the output is identical from normal `xr.concat` procedure and new manual concat procedure
- Run O3PROF requests in local Harmony successfully (equivalent requests fail in UAT)

### Overview of integration done

- Deployed new stitchee in local Harmony
- Compared output of new stitchee with previous version and confirm their equality

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--299.org.readthedocs.build/en/299/

<!-- readthedocs-preview stitchee end -->