### PR TITLE
Feature/issue 306: reprocess single granule scans to avoid concatenation in CONCISE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reprocess scan with single granule to prevent concatenation error in CONCISE ([#306](https://github.com/nasa/stitchee/pull/299))([**@ank1m**](https://github.com/ank1m))
+
+## [1.8.0] - 2025-09-16
+
+### Fixed
+
 - Handle variables with duplicate dimensions ([#299](https://github.com/nasa/stitchee/pull/299))([**@ank1m**](https://github.com/ank1m))
 - Handle non-concatenating variables of the same name for potential conflict ([#299](https://github.com/nasa/stitchee/pull/299))([**@ank1m**](https://github.com/ank1m))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reprocess scan with single granule to prevent concatenation error in CONCISE ([#306](https://github.com/nasa/stitchee/pull/299))([**@ank1m**](https://github.com/ank1m))
+- Reprocess scan with single granule to prevent concatenation error in CONCISE ([#306](https://github.com/nasa/stitchee/issues/306))([**@ank1m**](https://github.com/ank1m))
 
 ## [1.8.0] - 2025-09-16
 

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import shutil
 import time
 from collections.abc import Callable
 from functools import partial
@@ -90,7 +89,6 @@ def concatenate(
     output_file = validate_output_path(output_file, overwrite=overwrite_output_file)
 
     if num_input_files == 1:
-        # shutil.copyfile(input_files[0], output_file)
         xr.open_datatree(input_files[0]).to_netcdf(output_file)
         logger.info("Single workable file, copied to output path without modification.")
         return output_file

--- a/stitchee/concatenate.py
+++ b/stitchee/concatenate.py
@@ -90,7 +90,8 @@ def concatenate(
     output_file = validate_output_path(output_file, overwrite=overwrite_output_file)
 
     if num_input_files == 1:
-        shutil.copyfile(input_files[0], output_file)
+        # shutil.copyfile(input_files[0], output_file)
+        xr.open_datatree(input_files[0]).to_netcdf(output_file)
         logger.info("Single workable file, copied to output path without modification.")
         return output_file
 

--- a/tests/unit/test_scan_with_single_granule.py
+++ b/tests/unit/test_scan_with_single_granule.py
@@ -1,6 +1,7 @@
 """Test for processing single granule scan."""
 
 import os
+
 import xarray as xr
 
 from stitchee.concatenate import concatenate

--- a/tests/unit/test_scan_with_single_granule.py
+++ b/tests/unit/test_scan_with_single_granule.py
@@ -1,0 +1,24 @@
+"""Test for processing single granule scan."""
+
+import os
+import xarray as xr
+
+from stitchee.concatenate import concatenate
+
+from .. import data_for_tests_dir
+
+
+def test_no_files_to_concatenate(temp_output_dir):
+    input_granule = str(
+        data_for_tests_dir
+        / "harmony"
+        / "granules"
+        / "TEMPO_NO2_L2_V03_20240601T210934Z_S012G01_subsetted.nc4"
+    )
+    output_path = concatenate(
+        [input_granule],
+        output_file=os.path.join(temp_output_dir, "output.nc"),
+        concat_dim="mirror_step",
+    )
+
+    assert xr.open_datatree(input_granule).identical(xr.open_datatree(output_path))


### PR DESCRIPTION
GitHub Issue: #306

### Description

The concatenation error in CONCISE comes from a version mismatch between xarray used in Stitchee and in l2ss/CONCISE. Older xarray versions replicate inherited dimensions within each subgroup, whereas newer versions do not (breaking change introduced in 2025.8).

So, when concatenating multiple scans in CONCISE - one containing a single granule (1G) and another containing multiple granules (2G) - the dimension structures differ: 1G that comes from l2ss includes replicated dimensions per subgroup, while 2G that comes from stitchee does not. This inconsistency causes CONCISE, which relies on lower-level netCDF4 APIs, to miscalculate the maximum dimension size during concatenation.

### Solution

While waiting for l2ss update to support new xarray versions, a simple workaround in stitchee is to reprocess all scans, including the ones with single granules, instead of simply passing them along from l2ss. This ensures all scans (containing single or multiple granules) follow the same consistent standard (i.e., no replicated inherited dimensions). Once standardized, CONCISE can handle concatenation of all input files.

### Local test steps

- Deploy new stitchee in local Harmony
- For testing purposes, randomly select a set of scans, ensuring that at least one scan contains a single granule, and submit request that includes subsetting, extension and concatenation
- Repeat multiple times and confirm successful execution in workflow-ui

### Overview of integration done

- Deployed new stitchee in local Harmony
- Submit the same requests in UAT and local environment
- Confirm that requests containing scans with single granules are failing in UAT but successful in LOCAL

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--307.org.readthedocs.build/en/307/

<!-- readthedocs-preview stitchee end -->