### PR TITLE
Add copy of license to Docker build step to fix error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Add copy of license to Docker build step to fix error ([#311](https://github.com/nasa/stitchee/issues/311))([**@ank1m**](https://github.com/ank1m), [**@danielfromearth**](https://github.com/danielfromearth))
+
 ## [1.8.0] - 2025-09-16
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser --quiet --disabled-password --shell /bin/sh \
 WORKDIR /worker
 
 # Copy project files and install (as root for system-wide installation)
-COPY pyproject.toml README.md ./
+COPY pyproject.toml README.md LICENSE ./
 COPY stitchee/ ./stitchee/
 RUN poetry config virtualenvs.create false \
     && poetry install --extras "dev harmony"


### PR DESCRIPTION
GitHub Issue: #311 

### Description

This change adds the LICENSE file to the Docker build to ensure that `poetry install` can succeed.

### Local test steps

Built Docker image locally.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* ~[ ] Documentation updated (if needed).~


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--312.org.readthedocs.build/en/312/

<!-- readthedocs-preview stitchee end -->