### PR TITLE
Add release process documentation first draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add copy of license to Docker build step to fix error ([#311](https://github.com/nasa/stitchee/issues/311))([**@ank1m**](https://github.com/ank1m), [**@danielfromearth**](https://github.com/danielfromearth))
+- Add copy of license to Docker build step to fix error ([#313](https://github.com/nasa/stitchee/issues/313))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ## [1.8.0] - 2025-09-16
 

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -7,8 +7,7 @@
 3. Create a Pull Request from the `release/<version number>` branch to `main`
 
     1. Use previous Release PRs as a template for the description of the new release PR (Ensure *all* check boxes are unchecked, remove any previous issue links, and remove any ReadTheDocs preview.)
-  
+
     2. Determine which issues were addressed in this release version, and add links to them using the `Closes #<issue number>` pattern in the Release PR's description
 
 4. (Optional, if any new changes are desired, create PRs with target to release branch)
-

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,0 +1,14 @@
+# How to issue a release (and deploy) a new version of stitchee
+
+1. Check that all development Pull Requests have been merged into `develop`
+
+2. Create a new release branch (**from `develop`**), with the name pattern `release/<version number>`
+
+3. Create a Pull Request from the `release/<version number>` branch to `main`
+
+    1. Use previous Release PRs as a template for the description of the new release PR (Ensure *all* check boxes are unchecked, remove any previous issue links, and remove any ReadTheDocs preview.)
+  
+    2. Determine which issues were addressed in this release version, and add links to them using the `Closes #<issue number>` pattern in the Release PR's description
+
+4. (Optional, if any new changes are desired, create PRs with target to release branch)
+


### PR DESCRIPTION
GitHub Issue: #313 

### Description

Document the process for issuing a release and deploying a new version of stitchee.

### Local test steps

N/A

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).


<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--316.org.readthedocs.build/en/316/

<!-- readthedocs-preview stitchee end -->