### PR TITLE
Fix diagram error

### DIFF
--- a/docs/CI_CD_ARCHITECTURE_DIAGRAM.md
+++ b/docs/CI_CD_ARCHITECTURE_DIAGRAM.md
@@ -85,7 +85,7 @@ graph TB
         RP --> RQ{develop on release version?}
         RQ -->|Yes| RR[Bump develop to next minor<br/>1.11.0a5 → 1.12.0a1]
         RQ -->|No| RS[Skip - already bumped]
-        RR --> RT[Push with [skip ci]]
+        RR --> RT["Push with [skip ci]"]
     end
 
     subgraph "Production Release - publish.yml"


### PR DESCRIPTION
An error in `docs/CI_CD_ARCHITECTURE_DIAGRAM.md` is caused by nested square brackets in the Mermaid diagram syntax. Square brackets are used to define node shapes in Mermaid, so having [skip ci] inside the node text RT[Push with [skip ci]] creates a syntax conflict. By wrapping the text in quotes (RT["Push with [skip ci]"]), Mermaid will correctly parse the square brackets as part of the text content rather than syntax elements.

<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--323.org.readthedocs.build/en/323/

<!-- readthedocs-preview stitchee end -->