### PR TITLE
fix: Fail fast if output directory is invalid or not writable

### DIFF
--- a/stitchee/file_ops.py
+++ b/stitchee/file_ops.py
@@ -26,6 +26,13 @@ def validate_output_path(filepath: str, overwrite: bool = False) -> str:
     """
     path = Path(filepath).resolve()
 
+    # Ensure parent directory exists and is writable
+    if not path.parent.exists():
+        raise FileNotFoundError(f"Output directory does not exist: {path.parent}")
+
+    if not os.access(path.parent, os.W_OK):
+        raise PermissionError(f"Output directory is not writable: {path.parent}")
+
     if path.is_dir():
         raise TypeError(f"Output path '{path}' is a directory. Please specify a file path.")
 


### PR DESCRIPTION
I noticed that the tool doesn't verify if the output directory exists or is writable before starting the concatenation process.

If you're processing a large batch of files, it's pretty frustrating to wait for the whole thing to run only to fail at the very last second because of a typo in the output path or a permission issue.

I added a quick check in `validate_output_path` to fail fast if the destination folder isn't there or isn't writable. Seems like a safer default.

<!-- readthedocs-preview stitchee start -->
----
📚 Documentation preview 📚: https://stitchee--325.org.readthedocs.build/en/325/

<!-- readthedocs-preview stitchee end -->